### PR TITLE
Add Xorg configuration file

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config/xorg.conf
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config/xorg.conf
@@ -1,0 +1,12 @@
+Section "ServerLayout"
+	Identifier "Server0"
+	Option     "BlankTime"     "0"
+	Option     "StandbyTime"   "0"
+	Option     "SuspendTime"   "0"
+	Option     "OffTime"       "0"
+EndSection
+
+Section "Monitor"
+	Identifier "Monitor0"
+	Option     "DPMS" "false"
+EndSection

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
Adding xorg.conf file with default parameters. This allows enduser to
update configuration parameters as needed.

Issue: https://github.com/intel-aero/meta-intel-aero/issues/165