### PR TITLE
eee-acpi-scripts: Remove pm-utils dependency

### DIFF
--- a/recipes-core/eee-acpi-scripts/eee-acpi-scripts_git.bbappend
+++ b/recipes-core/eee-acpi-scripts/eee-acpi-scripts_git.bbappend
@@ -3,3 +3,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://0001-intel-aero-rename-PWRF-to-PBTN.patch \
 		file://0002-intel-aero-shutdown-to-handle-LED-toggling.patch \
 		"
+
+RDEPENDS_${PN}_remove = " pm-utils"


### PR DESCRIPTION
In fact it seems this runtime dependency is not really needed,
at least for Aero needs.