### PR TITLE
Add BIOS recipe

### DIFF
--- a/recipes-support/bios/bios.bb
+++ b/recipes-support/bios/bios.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "BIOS for Intel Aero compute board"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://Proprietary;md5=0557f9d92cf58f2ccdd50f62f8ac0b28"
+
+SRC_URI += "file://BIOSUPDATE.fv\
+	file://Proprietary\
+	"
+
+do_install_append() {
+	install -d ${D}/boot/
+	install -m 0755 ${WORKDIR}/BIOSUPDATE.fv ${D}/boot/
+}
+
+FILES_${PN} += "/boot/BIOSUPDATE.fv"

--- a/recipes-support/bios/files/Proprietary
+++ b/recipes-support/bios/files/Proprietary
@@ -1,0 +1,1 @@
+Proprietary license.


### PR DESCRIPTION
This should not be installed as default in the image, it is just here
to be able to generate a RPM that can be download and installed.

This have the new BIOS version 01.00.13, enabling modems.