### PR TITLE
initscripts-aero: ds4: Fix enumeration after reboot

### DIFF
--- a/recipes-core/initscripts-aero/files/aero-wd.service
+++ b/recipes-core/initscripts-aero/files/aero-wd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Start Aero watchdog
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/aero-watchdog
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/initscripts-aero/files/aero-wd.sh
+++ b/recipes-core/initscripts-aero/files/aero-wd.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-# Description: Startup the watchdog daemon 
-
-if [ -x /usr/bin/aero-watchdog ]; then 
-  /usr/bin/aero-watchdog &
-fi

--- a/recipes-core/initscripts-aero/files/ds4.service
+++ b/recipes-core/initscripts-aero/files/ds4.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Configure the power of DS4 camera
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ds4.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/initscripts-aero/files/ds4.sh
+++ b/recipes-core/initscripts-aero/files/ds4.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-# short-description: Start power DS4 by enabling regulator with GPIO
-# long-descriptioni: The script initializes ds4 (enable power) when 
-# booting to enable driver enumeration once system is ready.
+# DS4 power was turned on in BIOS 01.00.13 but this is causing DS4 not
+# be enumerated after a reboot, so here it is turned off and then on
+# fixing the enumeration problem.
 
 echo 405 > /sys/class/gpio/export
 echo out > /sys/class/gpio/gpio405/direction
+echo 0 > /sys/class/gpio/gpio405/value
+sleep 1
 echo 1 > /sys/class/gpio/gpio405/value

--- a/recipes-core/initscripts-aero/initscripts-aero_1.0.bb
+++ b/recipes-core/initscripts-aero/initscripts-aero_1.0.bb
@@ -1,7 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-
-SUMMARY = "SysV init scripts for Intel Aero"
-DESCRIPTION = "SysV init scripts for Intel Aero"
+DESCRIPTION = "Initialization scripts for Intel Aero"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=751419260aa954499f7abaabaa882bbe"
 PR = "r1"
@@ -10,41 +7,21 @@ INHIBIT_DEFAULT_DEPS = "1"
 
 S = "${WORKDIR}"
 
-#inherit update-alternatives
-#DEPENDS_append = " update-rc.d-native"
-#PACKAGE_WRITE_DEPS_append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+SRC_URI = "file://LICENSE"
+SRC_URI += "file://ds4.sh"
+SRC_URI += "file://ds4.service"
+SRC_URI += "file://aero-wd.service"
 
-SRC_URI += "file://LICENSE \
-            file://ds4.sh \
-	    file://aero-wd.sh \
-	   "
+inherit systemd
 
 do_install () {
-#
-# Create directories and install device independent scripts
-#
-	install -d ${D}${sysconfdir}/init.d
-	install -d ${D}${sysconfdir}/rcS.d
-	install -d ${D}${sysconfdir}/rc0.d
-	install -d ${D}${sysconfdir}/rc1.d
-	install -d ${D}${sysconfdir}/rc2.d
-	install -d ${D}${sysconfdir}/rc3.d
-	install -d ${D}${sysconfdir}/rc4.d
-	install -d ${D}${sysconfdir}/rc5.d
-	install -d ${D}${sysconfdir}/rc6.d
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/ds4.sh ${D}${bindir}
 
-	install -m 0755 ${WORKDIR}/ds4.sh ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/aero-wd.sh ${D}${sysconfdir}/init.d
-
-	ln -sf ../init.d/ds4.sh ${D}${sysconfdir}/rc1.d/S10ds4
-	ln -sf ../init.d/ds4.sh ${D}${sysconfdir}/rc2.d/S10ds4
-	ln -sf ../init.d/ds4.sh ${D}${sysconfdir}/rc3.d/S10ds4
-	ln -sf ../init.d/ds4.sh ${D}${sysconfdir}/rc4.d/S10ds4
-	ln -sf ../init.d/ds4.sh ${D}${sysconfdir}/rc5.d/S10ds4
-
-	ln -sf ../init.d/aero-wd.sh ${D}${sysconfdir}/rc1.d/S10aero-wd
-	ln -sf ../init.d/aero-wd.sh ${D}${sysconfdir}/rc2.d/S10aero-wd
-	ln -sf ../init.d/aero-wd.sh ${D}${sysconfdir}/rc3.d/S10aero-wd
-	ln -sf ../init.d/aero-wd.sh ${D}${sysconfdir}/rc4.d/S10aero-wd
-	ln -sf ../init.d/aero-wd.sh ${D}${sysconfdir}/rc5.d/S10aero-wd
+    install -d ${D}${systemd_unitdir}/system
+    install -D -m 0644 ${WORKDIR}/ds4.service ${D}${systemd_unitdir}/system
+    install -D -m 0644 ${WORKDIR}/aero-wd.service ${D}${systemd_unitdir}/system
 }
+
+SYSTEMD_SERVICE_${PN} += "ds4.service"
+SYSTEMD_SERVICE_${PN} += "aero-wd.service"


### PR DESCRIPTION
DS4 power was turned on in BIOS 01.00.13 but this is causing DS4 not
be enumerated after a reboot, so here it is turned off and then on
fixing the enumeration problem.