### PR TITLE
recipes-support: scripts: aerofc-update: Reduce time to go to bootloader

### DIFF
--- a/recipes-support/scripts/files/aerofc-update.sh
+++ b/recipes-support/scripts/files/aerofc-update.sh
@@ -54,10 +54,15 @@ if [ -n "$(fuser /dev/ttyS1)" ]; then
 fi
 
 echo -e "Updating firmware on AeroFC"
+
+aerofc-force-bootloader-pin.py 1
+
 /usr/sbin/px_uploader.py \
     --port /dev/ttyS1 \
     --baud-flightstack 460800,921600,1500000,115200 \
     "$1"
+
+aerofc-force-bootloader-pin.py 0
 
 # run router again if it was previously running
 if [ $router_running ]; then


### PR DESCRIPTION
Sometimes it takes a few interations between every baudrate before
flight stack get the message to reboot to bootloader.
Using aerofc-force-bootloader-pin.py will remove this problem if
the flight stack running already have this feature implemented,
PX4 from release 1.6v have and Ardupilot from release 1.5v or newer
already have.